### PR TITLE
build: set cargo flags on release profile to minimize build sizes

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -7,7 +7,10 @@ license = ""
 repository = ""
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[profile.release]
+opt-level = "z"
+lto = true
+
 
 [build-dependencies]
 tauri-build = { version = "1.5", features = [] }


### PR DESCRIPTION
This shrinks the resulting bundle size by ~50%